### PR TITLE
Support compilation with significantly stronger compiler warning flags.

### DIFF
--- a/include/statsd.hpp
+++ b/include/statsd.hpp
@@ -123,7 +123,7 @@ private:
 
     struct statsd_t
     {
-        struct sockaddr_in server;
+        struct sockaddr_in server = {};
         int sock = -1;
     };
 

--- a/src/statsd.cpp
+++ b/src/statsd.cpp
@@ -46,7 +46,7 @@ void statsd::open(const std::string& host, int16_t port)
 
         int error;
 
-        if ((error = getaddrinfo(host.c_str(), NULL, &hints, &result)))
+        if ((error = getaddrinfo(host.c_str(), nullptr, &hints, &result)))
         {
             statsd_error("StatsD: " + gai_strerror(error));
             return;
@@ -66,7 +66,7 @@ void statsd::open(const std::string& host, int16_t port)
             return;
         }
 
-        srandom(time(NULL));
+        srandom(static_cast<unsigned int>(time(nullptr)));
     }
 }
 
@@ -145,7 +145,7 @@ bool statsd::should_send(const float sample_rate)
 {
     if (sample_rate < 1.0)
     {
-        return (sample_rate > ((float)random() / RAND_MAX));
+        return (sample_rate > static_cast<float>(random() / RAND_MAX));
     }
     else
     {

--- a/test/statsd.cpp
+++ b/test/statsd.cpp
@@ -25,7 +25,8 @@ int main(int argc, char const *argv[])
 {
     /* Sample UDP server */
     std::thread server([]() {
-        int sockfd, n;
+        int sockfd;
+        ssize_t n;
         struct sockaddr_in servaddr, cliaddr;
         socklen_t len;
         char mesg[1000];


### PR DESCRIPTION
A project I'm using with ``statsd-cpp`` uses significantly stronger warning flags. It is usually recommended to use strong warning flags where possible (eg Item 1, "Compile cleanly at high warning levels" of C++ Coding Standards by Herb Sutter and Andrei Alexandrescu).

This pull request adds the warning flags I use for C++11 projects and makes the minimal changes required to resolve the resulting warnings from GCC 5.1.0.